### PR TITLE
Add web build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Ovaj repozitorijum sadrži početni kod za edukativnu mobilnu aplikaciju namenje
 
 Admin panel je uprošćena React aplikacija bez build procesa. Dovoljno je otvoriti `admin/index.html` u pregledaču. Pre toga u `admin/app.js` upisati Firebase konfiguraciju i autorizovati se kao profesor.
 
+## Pokretanje web verzije
+
+1. U direktorijumu `mobile/ProfaZaOsnovce` pokrenuti `npm run build:web` kako bi se pripremila statička verzija aplikacije u folderu `dist`.
+2. Na vrhu repozitorijuma izvršiti `npm install` da se instalira Express server.
+3. Pokrenuti `npm start` i otvoriti `http://localhost:3000` u pregledaču. Admin panel je dostupan na `http://localhost:3000/admin`.
+
 ## Napomena
 
 Kod predstavlja osnovu i služi kao polazna tačka. Za kompletnu funkcionalnost potrebno je dodatno razviti logiku na klijentu i u Firestore-u, kao i proširiti dizajn prema sopstvenim potrebama.

--- a/mobile/ProfaZaOsnovce/package.json
+++ b/mobile/ProfaZaOsnovce/package.json
@@ -7,7 +7,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "build:web": "expo export --platform web"
   },
   "dependencies": {
     "expo": "^50.0.0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "profa-server",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Path to exported web build from Expo
+const mobileBuild = path.join(__dirname, 'mobile/ProfaZaOsnovce/dist');
+app.use(express.static(mobileBuild));
+app.get('/', (req, res) => {
+  res.sendFile(path.join(mobileBuild, 'index.html'));
+});
+
+// Admin panel
+const adminPath = path.join(__dirname, 'admin');
+app.use('/admin', express.static(adminPath));
+app.get('/admin/*', (req, res) => {
+  res.sendFile(path.join(adminPath, 'index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add `build:web` npm script
- add simple Express server for local hosting
- document how to export web build and host it

## Testing
- `npm install --silent` *(fails: network restricted)*
- `npm run build:web` in `mobile/ProfaZaOsnovce` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c1207cf8832fa22facb7256ef1df