### PR TITLE
Add web app for scheduling student and professor sessions

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,393 @@
+const professors = [
+  { id: "prof1", name: "Ana Petrović", subject: "Matematika", password: "ana123" },
+  { id: "prof2", name: "Marko Jovanović", subject: "Fizika", password: "marko123" },
+  { id: "prof3", name: "Ivana Ilić", subject: "Hemija", password: "ivana123" },
+  { id: "prof4", name: "Luka Nikolić", subject: "Biologija", password: "luka123" },
+  { id: "prof5", name: "Jelena Ristić", subject: "Engleski", password: "jelena123" },
+  { id: "prof6", name: "Stefan Kovač", subject: "Programiranje", password: "stefan123" },
+  { id: "prof7", name: "Marija Stanković", subject: "Istorija", password: "marija123" },
+];
+
+const timeSlots = ["09:00", "10:30", "12:00", "13:30", "15:00", "16:30"];
+const bookingStorageKey = "jednorogBookingsV1";
+const viewerIdKey = "jednorogViewerId";
+
+let weeklySlots = [];
+let slotLookup = {};
+let bookings = {};
+let activeProfessorId = professors[0].id;
+let viewerId = getOrCreateViewerId();
+let currentSlotKey = null;
+let currentProfessorForModal = null;
+let loggedInProfessorId = null;
+
+const roleChoice = document.getElementById("role-choice");
+const studentView = document.getElementById("student-view");
+const professorView = document.getElementById("professor-view");
+const professorList = document.getElementById("professor-list");
+const calendarGrid = document.getElementById("calendar-grid");
+const activeProfessorName = document.getElementById("active-professor-name");
+const modal = document.getElementById("modal");
+const modalTitle = document.getElementById("modal-title");
+const modalSlotSummary = document.getElementById("modal-slot-summary");
+const bookingForm = document.getElementById("booking-form");
+const closeModalButton = document.getElementById("close-modal");
+const backToRole = document.getElementById("back-to-role");
+const backToRoleProfessor = document.getElementById("back-to-role-professor");
+const loginForm = document.getElementById("login-form");
+const loginSelect = document.getElementById("login-professor");
+const loginPassword = document.getElementById("login-password");
+const loginCard = document.getElementById("login-card");
+const professorDashboard = document.getElementById("professor-dashboard");
+const dashboardTitle = document.getElementById("dashboard-title");
+const bookingTable = document.getElementById("booking-table");
+const logoutButton = document.getElementById("logout");
+
+init();
+
+function init() {
+  bookings = loadBookings();
+  weeklySlots = generateWeeklySlots();
+  slotLookup = buildSlotLookup(weeklySlots);
+  renderProfessorChoices();
+  renderLoginOptions();
+  renderCalendar(activeProfessorId);
+  attachEvents();
+}
+
+function attachEvents() {
+  roleChoice?.addEventListener("click", (event) => {
+    const role = event.target?.dataset?.role;
+    if (!role) return;
+    if (role === "student") {
+      showStudentView();
+    } else {
+      showProfessorView();
+    }
+  });
+
+  backToRole?.addEventListener("click", resetToRoleChoice);
+  backToRoleProfessor?.addEventListener("click", resetToRoleChoice);
+
+  closeModalButton?.addEventListener("click", hideModal);
+  modal?.addEventListener("click", (event) => {
+    if (event.target === modal) hideModal();
+  });
+
+  bookingForm?.addEventListener("submit", handleBookingSubmit);
+  loginForm?.addEventListener("submit", handleLoginSubmit);
+  logoutButton?.addEventListener("click", handleLogout);
+}
+
+function renderProfessorChoices() {
+  professorList.innerHTML = "";
+  professors.forEach((prof) => {
+    const li = document.createElement("li");
+    li.className = "professor-item" + (prof.id === activeProfessorId ? " active" : "");
+    li.dataset.professorId = prof.id;
+
+    const info = document.createElement("div");
+    info.innerHTML = `<div class="professor-name">${prof.name}</div><div class="professor-subject">${prof.subject}</div>`;
+
+    const badge = document.createElement("span");
+    const bookedCount = getBookedCountForProfessor(prof.id);
+    badge.className = "badge";
+    badge.textContent = bookedCount ? `${bookedCount} termina` : "Novi termini";
+
+    li.appendChild(info);
+    li.appendChild(badge);
+    li.addEventListener("click", () => {
+      activeProfessorId = prof.id;
+      renderProfessorChoices();
+      renderCalendar(activeProfessorId);
+    });
+
+    professorList.appendChild(li);
+  });
+}
+
+function renderLoginOptions() {
+  loginSelect.innerHTML = "";
+  professors.forEach((prof) => {
+    const option = document.createElement("option");
+    option.value = prof.id;
+    option.textContent = `${prof.name} — ${prof.subject}`;
+    loginSelect.appendChild(option);
+  });
+}
+
+function showStudentView() {
+  studentView.classList.remove("hidden");
+  professorView.classList.add("hidden");
+}
+
+function showProfessorView() {
+  professorView.classList.remove("hidden");
+  studentView.classList.add("hidden");
+}
+
+function resetToRoleChoice() {
+  studentView.classList.add("hidden");
+  professorView.classList.add("hidden");
+  roleChoice.scrollIntoView({ behavior: "smooth" });
+}
+
+function renderCalendar(professorId) {
+  activeProfessorName.textContent = professors.find((p) => p.id === professorId)?.name || "";
+  calendarGrid.innerHTML = "";
+
+  weeklySlots.forEach((day) => {
+    const col = document.createElement("div");
+    col.className = "day-column";
+    const header = document.createElement("div");
+    header.innerHTML = `<div class="day-header">${day.label}</div><div class="day-date">${day.dateLabel}</div>`;
+    col.appendChild(header);
+
+    timeSlots.forEach((time) => {
+      const slotKey = `${day.iso}|${time}`;
+      const booking = bookings?.[professorId]?.[slotKey];
+      const slotBtn = createSlotButton({ slotKey, booking, time, dayLabel: day.label });
+      col.appendChild(slotBtn);
+    });
+
+    calendarGrid.appendChild(col);
+  });
+}
+
+function createSlotButton({ slotKey, booking, time, dayLabel }) {
+  const template = document.getElementById("slot-template");
+  const button = template.content.firstElementChild.cloneNode(true);
+  const status = getSlotStatus(booking);
+
+  button.innerHTML = `<span>${time}</span><small>${status}</small>`;
+  if (booking) {
+    const isMine = booking.studentId === viewerId;
+    button.classList.add(isMine ? "mine" : "busy");
+    button.disabled = !isMine;
+    button.title = isMine ? "Vaša rezervacija" : "Termin je zauzet";
+  } else {
+    button.addEventListener("click", () => {
+      currentSlotKey = slotKey;
+      currentProfessorForModal = activeProfessorId;
+      modalTitle.textContent = `Rezervišite termin`;
+      modalSlotSummary.textContent = `${dayLabel}, ${time} sa profesorom ${activeProfessorName.textContent}`;
+      showModal();
+    });
+  }
+
+  return button;
+}
+
+function getSlotStatus(booking) {
+  if (!booking) return "Slobodan";
+  return booking.studentId === viewerId ? "Vaš termin" : "Zauzeto";
+}
+
+function showModal() {
+  modal.classList.remove("hidden");
+}
+
+function hideModal() {
+  modal.classList.add("hidden");
+  bookingForm.reset();
+  currentSlotKey = null;
+}
+
+function handleBookingSubmit(event) {
+  event.preventDefault();
+  if (!currentSlotKey || !currentProfessorForModal) return;
+
+  const name = document.getElementById("student-name").value.trim();
+  const grade = document.getElementById("student-grade").value;
+  const phone = document.getElementById("student-phone").value.trim();
+
+  if (!name || !grade || !phone) return;
+
+  const professorBookings = bookings[currentProfessorForModal] || {};
+  if (professorBookings[currentSlotKey] && professorBookings[currentSlotKey].studentId !== viewerId) {
+    alert("Termin je upravo zauzet. Molimo izaberite drugi.");
+    hideModal();
+    renderCalendar(currentProfessorForModal);
+    return;
+  }
+
+  professorBookings[currentSlotKey] = {
+    studentName: name,
+    grade,
+    phone,
+    studentId: viewerId,
+    createdAt: new Date().toISOString(),
+  };
+
+  bookings[currentProfessorForModal] = professorBookings;
+  saveBookings(bookings);
+  hideModal();
+  renderProfessorChoices();
+  renderCalendar(currentProfessorForModal);
+  if (loggedInProfessorId === currentProfessorForModal) {
+    renderProfessorBookings(loggedInProfessorId);
+  }
+  alert("Uspešno ste zakazali termin!");
+}
+
+function handleLoginSubmit(event) {
+  event.preventDefault();
+  const selectedProf = loginSelect.value;
+  const password = loginPassword.value.trim();
+  const prof = professors.find((p) => p.id === selectedProf);
+
+  if (!prof || prof.password !== password) {
+    alert("Pogrešna lozinka. Pokušajte ponovo.");
+    return;
+  }
+
+  loggedInProfessorId = prof.id;
+  dashboardTitle.textContent = `${prof.name} — ${prof.subject}`;
+  loginCard.classList.add("hidden");
+  professorDashboard.classList.remove("hidden");
+  renderProfessorBookings(loggedInProfessorId);
+  loginPassword.value = "";
+}
+
+function handleLogout() {
+  loggedInProfessorId = null;
+  professorDashboard.classList.add("hidden");
+  loginCard.classList.remove("hidden");
+}
+
+function renderProfessorBookings(professorId) {
+  const profBookings = bookings[professorId] || {};
+  const rows = Object.entries(profBookings).map(([key, details]) => {
+    const slot = slotLookup[key] || fallbackSlot(key);
+    return {
+      key,
+      slot,
+      details,
+    };
+  });
+
+  rows.sort((a, b) => new Date(a.slot.dateTime) - new Date(b.slot.dateTime));
+
+  if (!rows.length) {
+    bookingTable.innerHTML = `<p class="hint">Još uvek nema zakazanih termina.</p>`;
+    return;
+  }
+
+  const table = document.createElement("table");
+  const thead = document.createElement("thead");
+  thead.innerHTML = `<tr><th>Datum</th><th>Vreme</th><th>Učenik</th><th>Razred</th><th>Telefon</th></tr>`;
+  table.appendChild(thead);
+
+  const tbody = document.createElement("tbody");
+  rows.forEach(({ slot, details }) => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${slot.dateLabel}</td>
+      <td>${slot.time}</td>
+      <td>${details.studentName}</td>
+      <td>${formatGrade(details.grade)}</td>
+      <td>${details.phone}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+
+  bookingTable.innerHTML = "";
+  bookingTable.appendChild(table);
+}
+
+function formatGrade(grade) {
+  if (!grade) return "";
+  if (grade === "srednja") return "Srednja škola";
+  return `${grade}. razred`;
+}
+
+function fallbackSlot(key) {
+  const [date, time] = key.split("|");
+  return {
+    dateLabel: formatDateLabel(date),
+    time,
+    dateTime: `${date}T${time}`,
+  };
+}
+
+function getBookedCountForProfessor(professorId) {
+  return Object.keys(bookings[professorId] || {}).length;
+}
+
+function generateWeeklySlots() {
+  const start = startOfWeek(new Date());
+  const days = [];
+  const weekdayNames = ["Ponedeljak", "Utorak", "Sreda", "Četvrtak", "Petak", "Subota", "Nedelja"];
+
+  for (let i = 0; i < 7; i++) {
+    const date = new Date(start);
+    date.setDate(start.getDate() + i);
+    const iso = date.toISOString().slice(0, 10);
+    days.push({
+      iso,
+      label: weekdayNames[i],
+      dateLabel: formatDateLabel(iso),
+      dateTime: date,
+    });
+  }
+
+  return days;
+}
+
+function buildSlotLookup(days) {
+  const map = {};
+  days.forEach((day) => {
+    timeSlots.forEach((time) => {
+      const key = `${day.iso}|${time}`;
+      map[key] = {
+        dateLabel: day.dateLabel,
+        dayLabel: day.label,
+        time,
+        dateTime: `${day.iso}T${time}`,
+      };
+    });
+  });
+  return map;
+}
+
+function startOfWeek(date) {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = (day === 0 ? -6 : 1) - day; // Monday as start
+  d.setDate(d.getDate() + diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function formatDateLabel(isoDate) {
+  const [year, month, day] = isoDate.split("-").map(Number);
+  return `${String(day).padStart(2, "0")}.${String(month).padStart(2, "0")}.`; // dd.mm.
+}
+
+function loadBookings() {
+  try {
+    const stored = localStorage.getItem(bookingStorageKey);
+    return stored ? JSON.parse(stored) : {};
+  } catch (error) {
+    console.error("Neuspešno učitavanje", error);
+    return {};
+  }
+}
+
+function saveBookings(data) {
+  try {
+    localStorage.setItem(bookingStorageKey, JSON.stringify(data));
+  } catch (error) {
+    console.error("Neuspešno čuvanje", error);
+  }
+}
+
+function getOrCreateViewerId() {
+  let id = localStorage.getItem(viewerIdKey);
+  if (!id) {
+    id = crypto.randomUUID ? crypto.randomUUID() : `student-${Date.now()}`;
+    localStorage.setItem(viewerIdKey, id);
+  }
+  return id;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="sr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Jednorog | Zakazivanje časova</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="hero">
+    <div class="hero__content">
+      <p class="eyebrow">AI Jednorog</p>
+      <h1>Zakazivanje privatnih časova</h1>
+      <p class="lede">
+        Izaberite da li ste učenik ili profesor i upravljajte terminima na jednom mestu.
+      </p>
+      <div class="role-choices" id="role-choice">
+        <button class="pill" data-role="student">Ja sam učenik</button>
+        <button class="pill pill--secondary" data-role="professor">Ja sam profesor</button>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section id="student-view" class="panel hidden">
+      <div class="panel__header">
+        <div>
+          <p class="eyebrow">Učenik</p>
+          <h2>Pronađite termin i rezervišite čas</h2>
+        </div>
+        <p class="hint">Kliknite na profesora sa leve strane, a zatim izaberite slobodan termin u kalendaru.</p>
+      </div>
+
+      <div class="layout">
+        <aside class="sidebar">
+          <h3>Profesori</h3>
+          <ul id="professor-list" class="professor-list"></ul>
+        </aside>
+
+        <section class="calendar">
+          <header class="calendar__header">
+            <div>
+              <p class="eyebrow">Kalendar termina</p>
+              <h3 id="active-professor-name">&nbsp;</h3>
+            </div>
+            <button class="ghost" id="back-to-role">Promeni ulogu</button>
+          </header>
+          <div class="calendar__legend">
+            <span class="legend legend--free">Slobodan</span>
+            <span class="legend legend--mine">Vaš termin</span>
+            <span class="legend legend--busy">Zauzeto</span>
+          </div>
+          <div id="calendar-grid" class="calendar__grid"></div>
+        </section>
+      </div>
+    </section>
+
+    <section id="professor-view" class="panel hidden">
+      <div class="panel__header">
+        <div>
+          <p class="eyebrow">Profesor</p>
+          <h2>Prijavite se da vidite svoje termine</h2>
+        </div>
+        <button class="ghost" id="back-to-role-professor">Promeni ulogu</button>
+      </div>
+
+      <div class="card" id="login-card">
+        <form id="login-form" class="form-grid">
+          <label>
+            <span>Izaberite profesora</span>
+            <select id="login-professor" required></select>
+          </label>
+          <label>
+            <span>Lozinka</span>
+            <input type="password" id="login-password" placeholder="Lozinka" required />
+          </label>
+          <button type="submit" class="pill">Prijava</button>
+          <p class="hint">Test lozinke su jednostavne (npr. "ana123").</p>
+        </form>
+      </div>
+
+      <div class="card hidden" id="professor-dashboard">
+        <div class="dashboard__header">
+          <div>
+            <p class="eyebrow">Pregled termina</p>
+            <h3 id="dashboard-title">&nbsp;</h3>
+          </div>
+          <button class="ghost" id="logout">Odjava</button>
+        </div>
+        <div id="booking-table" class="table"></div>
+      </div>
+    </section>
+  </main>
+
+  <div id="modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div class="modal__content">
+      <div class="modal__header">
+        <div>
+          <p class="eyebrow">Rezervacija termina</p>
+          <h3 id="modal-title">Izaberite termin</h3>
+          <p id="modal-slot-summary" class="hint"></p>
+        </div>
+        <button class="ghost" id="close-modal" aria-label="Zatvori">✕</button>
+      </div>
+      <form id="booking-form" class="form-grid">
+        <label>
+          <span>Ime i prezime</span>
+          <input type="text" id="student-name" placeholder="Vaše ime" required />
+        </label>
+        <label>
+          <span>Razred</span>
+          <select id="student-grade" required>
+            <option value="">Izaberite</option>
+            <option value="5">5. razred</option>
+            <option value="6">6. razred</option>
+            <option value="7">7. razred</option>
+            <option value="8">8. razred</option>
+            <option value="srednja">Srednja škola</option>
+          </select>
+        </label>
+        <label>
+          <span>Telefon</span>
+          <input type="tel" id="student-phone" placeholder="06x xxx xxxx" required />
+        </label>
+        <button type="submit" class="pill">Zakaži termin</button>
+      </form>
+    </div>
+  </div>
+
+  <template id="slot-template">
+    <button class="slot" type="button"></button>
+  </template>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,434 @@
+:root {
+  --bg: #0b1021;
+  --card: #111831;
+  --accent: #6dd3ff;
+  --accent-strong: #7cf2c5;
+  --text: #eaf4ff;
+  --muted: #a8b3cf;
+  --border: #22304f;
+  --busy: #ff9e7a;
+  --mine: #a1f26a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at 15% 20%, rgba(109, 211, 255, 0.12), transparent 35%),
+    radial-gradient(circle at 80% 10%, rgba(124, 242, 197, 0.15), transparent 30%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+h1, h2, h3, h4 {
+  margin: 0;
+  color: #f6fbff;
+}
+
+p {
+  margin: 0;
+  color: var(--muted);
+}
+
+a {
+  color: var(--accent);
+}
+
+main {
+  padding: 0 24px 64px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.hero {
+  padding: 56px 24px 32px;
+  background: linear-gradient(135deg, rgba(109, 211, 255, 0.18), rgba(124, 242, 197, 0.12));
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.hero__content {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.eyebrow {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.lede {
+  margin-top: 8px;
+  max-width: 580px;
+}
+
+.role-choices {
+  display: flex;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.panel {
+  margin-top: 32px;
+  background: rgba(17, 24, 49, 0.75);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 20px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(10px);
+}
+
+.panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 18px;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+.sidebar {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+  position: sticky;
+  top: 16px;
+}
+
+.sidebar h3 {
+  margin-bottom: 12px;
+}
+
+.professor-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.professor-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 12px;
+  padding: 12px 10px;
+  cursor: pointer;
+  transition: border-color 0.2s, transform 0.15s;
+}
+
+.professor-item:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.professor-item.active {
+  border-color: var(--accent);
+  box-shadow: 0 8px 20px rgba(109, 211, 255, 0.15);
+}
+
+.professor-name {
+  font-weight: 700;
+}
+
+.professor-subject {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.badge {
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  background: rgba(109, 211, 255, 0.08);
+}
+
+.calendar {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+}
+
+.calendar__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.calendar__legend {
+  display: flex;
+  gap: 8px;
+  margin: 12px 0;
+  flex-wrap: wrap;
+}
+
+.legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 13px;
+  border: 1px solid var(--border);
+  color: var(--muted);
+}
+
+.legend::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.legend--free::before { background: var(--accent); }
+.legend--busy::before { background: var(--busy); }
+.legend--mine::before { background: var(--mine); }
+
+.calendar__grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(120px, 1fr));
+  gap: 8px;
+}
+
+.day-column {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px;
+  background: rgba(255, 255, 255, 0.02);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.day-header {
+  font-weight: 700;
+  color: #f3f7ff;
+}
+
+.day-date {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.slot {
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: rgba(109, 211, 255, 0.06);
+  color: var(--text);
+  cursor: pointer;
+  transition: border-color 0.15s, transform 0.12s;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.slot small {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.slot:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.slot.busy {
+  background: rgba(255, 158, 122, 0.16);
+  border-color: rgba(255, 158, 122, 0.6);
+  cursor: not-allowed;
+}
+
+.slot.mine {
+  background: rgba(161, 242, 106, 0.14);
+  border-color: rgba(161, 242, 106, 0.6);
+}
+
+.hint {
+  color: var(--muted);
+  margin: 6px 0 0;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+  margin-top: 12px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  align-items: end;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+  color: #f3f7ff;
+}
+
+input, select {
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  font-size: 15px;
+}
+
+.pill {
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #05122a;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 12px 30px rgba(109, 211, 255, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.pill:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 40px rgba(109, 211, 255, 0.45);
+}
+
+.pill--secondary {
+  background: transparent;
+  border: 1px solid var(--accent);
+  color: var(--text);
+}
+
+.ghost {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 10px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.hidden {
+  display: none;
+}
+
+.table {
+  margin-top: 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th, .table td {
+  padding: 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+.table th {
+  background: rgba(255, 255, 255, 0.04);
+  color: #f6fbff;
+}
+
+.table tr:last-child td {
+  border-bottom: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  z-index: 20;
+}
+
+.modal__content {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 18px;
+  width: min(560px, 100%);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+}
+
+.modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.dashboard__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+  }
+
+  .calendar__grid {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding: 40px 16px 20px;
+  }
+
+  main {
+    padding: 0 16px 48px;
+  }
+
+  .calendar__grid {
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  }
+}


### PR DESCRIPTION
## Summary
- add single-page layout with role selection for učenik i profesor
- implement nedeljni kalendar sa sedam profesora, rezervacijom termina i unosom podataka u lokalnoj memoriji
- dodaj login za profesore sa tabelarnim pregledom prijavljenih učenika

## Testing
- Not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940c6e20dcc832fbf5308f0213c0cb5)